### PR TITLE
Feature/add fake smtp server GDEV-217

### DIFF
--- a/.devcontainer/.sandbox_notification.yaml
+++ b/.devcontainer/.sandbox_notification.yaml
@@ -3,3 +3,9 @@ rabbitmq_port: 5672
 topic_name: send_notification
 max_attempts: 1
 log_level: debug
+smtp_server: fakesmtp
+smtp_port: 2525
+smtp_username: Example
+smtp_password: example
+sender_email: example@example.org
+smtp_use_tls: false

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -26,9 +26,6 @@ services:
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
-    env_file:
-      - ./.env
-
   rabbitmq:
     image: rabbitmq:3-management
     container_name: 'rabbitmq'
@@ -38,3 +35,9 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
+
+  fakesmtp:
+    image: ghga/fakesmtp:latest
+    command: -a 0.0.0.0 --background --output-dir /var/mail --port 2525 --start-server
+    ports:
+      - 2525:2525

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,6 +1,7 @@
 smtp_server: smtp.gmail.com
 smtp_port: 587
 sender_email: your-email-here
+smtp_use_tls: false
 
 rabbitmq_host: localhost
 rabbitmq_port: 5672

--- a/sandbox_notification/config.py
+++ b/sandbox_notification/config.py
@@ -32,6 +32,7 @@ class Config(BaseSettings):
     smtp_port: int
     smtp_username: str
     smtp_password: str
+    smtp_use_tls: bool = True
     sender_email: str
 
     rabbitmq_host: str

--- a/sandbox_notification/core/send.py
+++ b/sandbox_notification/core/send.py
@@ -43,7 +43,7 @@ def send_email(data: dict):
 
             server = smtplib.SMTP(config.smtp_server, config.smtp_port)
 
-            server.starttls()
+            # server.starttls()
 
             server.ehlo()
 


### PR DESCRIPTION
Suggestions for squash and merge:

Title:
```
Added fake SMTP server for development (GDEV-217)
```

Description:
```
Added a fake SMTP server that runs as a separate container.
Mails can be found in `/dev/mail` in the `fakesmtp` container
```